### PR TITLE
Proxy protocol v2 implementation

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-OSERL 3.2.3 needs common_lib 3.3.0 or higher.
+OSERL 3.3.0 needs common_lib 3.3.0 or higher.
 
 Documentation available in man format:
 

--- a/ebin/oserl.app
+++ b/ebin/oserl.app
@@ -1,11 +1,12 @@
 {application, oserl, [
     {description, "Open SMPP Erlang Library"},
-    {vsn, "3.2.4"},
+    {vsn, "3.2.5"},
     {modules, [
         gen_esme_session,
         gen_esme,
         gen_mc_session,
         gen_mc,
+        proxy_protocol,
         smpp_base,
         smpp_base_syntax,
         smpp_disk_log_hlr,

--- a/ebin/oserl.app
+++ b/ebin/oserl.app
@@ -1,6 +1,6 @@
 {application, oserl, [
     {description, "Open SMPP Erlang Library"},
-    {vsn, "3.2.5"},
+    {vsn, "3.3.0"},
     {modules, [
         gen_esme_session,
         gen_esme,

--- a/ebin/oserl.app
+++ b/ebin/oserl.app
@@ -7,6 +7,7 @@
         gen_mc_session,
         gen_mc,
         proxy_protocol,
+        time,
         smpp_base,
         smpp_base_syntax,
         smpp_disk_log_hlr,

--- a/ebin/oserl.app.src
+++ b/ebin/oserl.app.src
@@ -1,6 +1,6 @@
 {application, oserl, [
     {description, "Open SMPP Erlang Library"},
-    {vsn, "3.2.5"},
+    {vsn, "3.3.0"},
     {modules, [
         gen_esme_session,
         gen_esme,

--- a/ebin/oserl.app.src
+++ b/ebin/oserl.app.src
@@ -7,6 +7,7 @@
         gen_mc_session,
         gen_mc,
         proxy_protocol,
+        time,
         smpp_base,
         smpp_base_syntax,
         smpp_disk_log_hlr,

--- a/ebin/oserl.app.src
+++ b/ebin/oserl.app.src
@@ -1,0 +1,27 @@
+{application, oserl, [
+    {description, "Open SMPP Erlang Library"},
+    {vsn, "3.2.5"},
+    {modules, [
+        gen_esme_session,
+        gen_esme,
+        gen_mc_session,
+        gen_mc,
+        proxy_protocol,
+        smpp_base,
+        smpp_base_syntax,
+        smpp_disk_log_hlr,
+        smpp_error,
+        smpp_log_mgr,
+        smpp_operation,
+        smpp_param_syntax,
+        smpp_pdu_syntax,
+        smpp_ref_num,
+        smpp_req_tab,
+        smpp_session,
+        smpp_sm,
+        smpp_tty_log_hlr
+    ]},
+    {registered, []},
+    {applications, [kernel, stdlib, common_lib]},
+    {env, []}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {lib_dirs, ["deps"]}.
 
 {erl_opts, [
-  warnings_as_errors,
+%%  warnings_as_errors, %%not compatible with old rebar
   debug_info,
   {parse_transform, lager_transform}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,6 @@
 {lib_dirs, ["deps"]}.
 
 {erl_opts, [
-%%  warnings_as_errors, %%not compatible with old rebar
   debug_info,
   {parse_transform, lager_transform}
 ]}.

--- a/src/proxy_protocol.erl
+++ b/src/proxy_protocol.erl
@@ -12,7 +12,7 @@
                       connection_info = []}).
 -opaque proxy_opts() :: #proxy_opts{}.
 
--define(WAITING_TIMEOUT, 10000).
+-define(WAITING_TIMEOUT, 1000).
 
 -export_type([proxy_opts/0]).
 %%%-----------------------------------------------------------------------------

--- a/src/proxy_protocol.erl
+++ b/src/proxy_protocol.erl
@@ -1,0 +1,133 @@
+-module(proxy_protocol).
+
+-include("proxy_protocol.hrl").
+
+-export([accept/1]).
+
+-record(proxy_opts, { inet_version :: ipv4|ipv6,
+                      source_address :: inet:ip_address(),
+                      dest_address :: inet:ip_address(),
+                      source_port :: inet:port_number(),
+                      dest_port :: inet:port_number(),
+                      connection_info = []}).
+-opaque proxy_opts() :: #proxy_opts{}.
+
+-export_type([proxy_opts/0]).
+%%%-----------------------------------------------------------------------------
+%%% EXPORTS
+%%%-----------------------------------------------------------------------------
+accept(Sock) ->
+    inet:setopts(Sock, [{active, once}, {packet, line}]),
+    receive
+      {_, CSocket, <<"\r\n">>} ->
+          ok = inet:setopts(Sock, [{packet, raw}]),
+          {ok, ProxyHeader} = gen_tcp:recv(CSocket, 14, 1000),
+          case parse_proxy_protocol_v2(<<"\r\n", ProxyHeader/binary>>) of
+              {proxy, ipv4, _Protocol, Length} ->
+                  {ok, ProxyAddr} = gen_tcp:recv(CSocket, Length, 1000),
+                  case ProxyAddr of
+                      <<SA1:8, SA2:8, SA3:8, SA4:8,
+                        DA1:8, DA2:8, DA3:8, DA4:8,
+                        SourcePort:16, DestPort:16, Rest/binary>> ->
+                          SourceAddress = {SA1, SA2, SA3, SA4},
+                          DestAddress = {DA1, DA2, DA3, DA4},
+                          ConnectionInfo = parse_tlv(Rest),
+                          {ok, #proxy_opts{inet_version = ipv4,
+                                           source_address = SourceAddress,
+                                           dest_address = DestAddress,
+                                           source_port = SourcePort,
+                                           dest_port = DestPort,
+                                           connection_info = ConnectionInfo}};
+                      _ ->
+                          gen_tcp:close(Sock),
+                          {error, not_proxy_protocol}
+                  end;
+              _Unsupported ->
+                  gen_tcp:close(Sock),
+                  {error, not_supported_v2}
+            end;
+        {_, _CSocket, Data} ->
+            lager:notice("data: ~p", [Data])
+    end.
+
+%%%-----------------------------------------------------------------------------
+%%% INTERNAL FUNCTIONS
+%%%-----------------------------------------------------------------------------
+parse_proxy_protocol_v2(<<?HEADER, (?VSN):4, 0:4, X:4, Y:4, Len:16>>) ->
+    {local, family(X), protocol(Y), Len};
+parse_proxy_protocol_v2(<<?HEADER, (?VSN):4, 1:4, X:4, Y:4, Len:16>>) ->
+    {proxy, family(X), protocol(Y), Len};
+parse_proxy_protocol_v2(_) ->
+    not_proxy_protocol.
+
+parse_tlv(Rest) ->
+    parse_tlv(Rest, []).
+
+parse_tlv(<<>>, Result) ->
+    Result;
+parse_tlv(<<Type:8, Len:16, Value:Len/binary, Rest/binary>>, Result) ->
+    case pp2_type(Type) of
+        ssl ->
+            parse_tlv(Rest, pp2_value(Type, Value) ++ Result);
+        TypeName ->
+            parse_tlv(Rest, [{TypeName, Value} | Result])
+    end;
+parse_tlv(_, _) ->
+    {error, parse_tlv}.
+
+pp2_type(?PP2_TYPE_ALPN) ->
+    negotiated_protocol;
+pp2_type(?PP2_TYPE_AUTHORITY) ->
+    authority;
+pp2_type(?PP2_TYPE_SSL) ->
+    ssl;
+pp2_type(?PP2_SUBTYPE_SSL_VERSION) ->
+    protocol;
+pp2_type(?PP2_SUBTYPE_SSL_CN) ->
+    sni_hostname;
+pp2_type(?PP2_TYPE_NETNS) ->
+    netns;
+pp2_type(_) ->
+    invalid_pp2_type.
+
+pp2_value(?PP2_TYPE_SSL, <<Client:1/binary, _:32, Rest/binary>>) ->
+    case pp2_client(Client) of % validates bitfield format, but ignores data
+        invalid_client ->
+            invalid;
+        _ ->
+            %% Fetches TLV values attached, regardless of if the client
+            %% specified SSL. If this is a problem, then we should fix,
+            %% but in any case the blame appears to be on the sender
+            %% who is giving us broken headers.
+            parse_tlv(Rest)
+    end;
+pp2_value(_, Value) ->
+    Value.
+
+pp2_client(<<0:5,             % UNASSIGNED
+             _ClientCert:1,   % PP2_CLIENT_CERT_SESS
+             _ClientCert:1,   % PP2_CLIENT_CERT_CONN
+             _ClientSSL:1>>) ->
+    client_ssl;
+pp2_client(_) ->
+    invalid_client.
+
+family(?AF_UNSPEC) ->
+    af_unspec;
+family(?AF_INET) ->
+    ipv4;
+family(?AF_INET6) ->
+    ipv6;
+family(?AF_UNIX) ->
+    af_unix;
+family(_) ->
+    {error, invalid_address_family}.
+
+protocol(?UNSPEC) ->
+    unspec;
+protocol(?STREAM) ->
+    stream;
+protocol(?DGRAM) ->
+    dgram;
+protocol(_) ->
+    {error, invalid_protocol}.

--- a/src/proxy_protocol.hrl
+++ b/src/proxy_protocol.hrl
@@ -1,0 +1,27 @@
+%%% proxy2 defines
+-define(HEADER, "\r\n\r\n\0\r\nQUIT\n").
+-define(VSN, 16#02).
+
+%% Protocol types
+-define(AF_UNSPEC, 16#00).
+-define(AF_INET, 16#01).
+-define(AF_INET6, 16#02).
+-define(AF_UNIX, 16#03).
+
+%% Transfer types
+-define(UNSPEC, 16#00).
+-define(STREAM, 16#01).
+-define(DGRAM, 16#02).
+
+%% TLV types for additional headers
+-define(PP2_TYPE_ALPN, 16#01).
+-define(PP2_TYPE_AUTHORITY, 16#02).
+-define(PP2_TYPE_SSL, 16#20).
+-define(PP2_SUBTYPE_SSL_VERSION, 16#21).
+-define(PP2_SUBTYPE_SSL_CN, 16#22).
+-define(PP2_TYPE_NETNS, 16#30).
+
+%% SSL Client fields
+-define(PP2_CLIENT_SSL, 16#01).
+-define(PP2_CLIENT_CERT_CONN, 16#02).
+-define(PP2_CLIENT_CERT_SESS, 16#04).

--- a/src/smpp_session.erl
+++ b/src/smpp_session.erl
@@ -218,11 +218,11 @@ default_addr() ->
     {ok, Addr} = inet:getaddr(Host, inet),
     Addr.
 
-handle_accept(Pid, Sock, ProxyProtocol) ->
+handle_accept(Pid, Sock, ProxyIpList) ->
     case inet:peername(Sock) of
         {ok, {Addr, _Port}} ->
-            lager:debug("sync_send_event accept to pid:~p Addr:~p, proxy_protocol: ~p", [Pid, Addr, ProxyProtocol]),
-            case ProxyProtocol of
+            lager:debug("sync_send_event accept to pid:~p Addr:~p, proxy_ip_list: ~p", [Pid, Addr, ProxyIpList]),
+            case lists:meber(Addr, ProxyIpList) of
                 true -> case proxy_protocol:accept(Sock) of
                             {ok, {proxy_opts, _IpVersion, SourceAddress, DestAddress, SourcePort, DestPort, ConnectionInfo}} ->
                                 gen_fsm:sync_send_event(Pid,

--- a/src/smpp_session.erl
+++ b/src/smpp_session.erl
@@ -35,7 +35,7 @@
 -export([congestion/3, connect/1, listen/1, tcp_send/2, send_pdu/3]).
 
 %%% SOCKET LISTENER FUNCTIONS EXPORTS
--export([wait_accept/3, wait_recv/3, recv_loop/4]).
+-export([wait_accept/4, wait_accept/3, wait_recv/3, recv_loop/4]).
 
 %% TIMER EXPORTS
 -export([cancel_timer/1, start_timer/2]).
@@ -82,6 +82,7 @@ congestion(CongestionSt, WaitTime, Timestamp) ->
 
 connect(Opts) ->
     Ip = proplists:get_value(ip, Opts),
+    lager:debug("smpp_session connect opts: ~p", [Opts]),
     case proplists:get_value(sock, Opts, undefined) of
         undefined ->
             Addr = proplists:get_value(addr, Opts),
@@ -96,6 +97,7 @@ connect(Opts) ->
 
 
 listen(Opts) ->
+    lager:debug("smpp_session listen opts: ~p", [Opts]),
     case proplists:get_value(lsock, Opts, undefined) of
         undefined ->
             Addr = proplists:get_value(addr, Opts, default_addr()),
@@ -142,14 +144,17 @@ send_pdu(Sock, Pdu, Log) ->
 %%% SOCKET LISTENER FUNCTIONS
 %%%-----------------------------------------------------------------------------
 wait_accept(Pid, LSock, Log) ->
+    wait_accept(Pid, LSock, Log, false).
+
+wait_accept(Pid, LSock, Log, ProxyProtocol) ->
     case gen_tcp:accept(LSock) of
         {ok, Sock} ->
-            case handle_accept(Pid, Sock) of
+            case handle_accept(Pid, Sock, ProxyProtocol) of
                 true ->
                     ?MODULE:recv_loop(Pid, Sock, <<>>, Log);
                 false ->
                     gen_tcp:close(Sock),
-                    ?MODULE:wait_accept(Pid, LSock, Log)
+                    ?MODULE:wait_accept(Pid, LSock, Log, ProxyProtocol)
             end;
         {error, Reason} ->
             gen_fsm:send_all_state_event(Pid, {listen_error, Reason})
@@ -213,16 +218,24 @@ default_addr() ->
     {ok, Addr} = inet:getaddr(Host, inet),
     Addr.
 
-
-handle_accept(Pid, Sock) ->
+handle_accept(Pid, Sock, ProxyProtocol) ->
     case inet:peername(Sock) of
         {ok, {Addr, _Port}} ->
-            lager:debug("sync_send_event accept to pid:~p Addr:~p", [Pid, Addr]),
-            gen_fsm:sync_send_event(Pid, {accept, Sock, Addr});
+            lager:debug("sync_send_event accept to pid:~p Addr:~p, proxy_protocol: ~p", [Pid, Addr, ProxyProtocol]),
+            case ProxyProtocol of
+                true -> case proxy_protocol:accept(Sock) of
+                            {ok, {proxy_opts, _IpVersion, SourceAddress, DestAddress, SourcePort, DestPort, ConnectionInfo}} ->
+                                gen_fsm:sync_send_event(Pid,
+                                  {accept, Sock, {Addr, [
+                                    SourceAddress, DestAddress, SourcePort, DestPort, ConnectionInfo
+                                ]}});
+                            {error, _Reason} -> false
+                        end;
+                false -> gen_fsm:sync_send_event(Pid, {accept, Sock, Addr})
+            end;
         {error, _Reason} ->  % Most probably the socket is closed
             false
     end.
-
 
 handle_input(Pid, <<CmdLen:32, Rest/binary>> = Buffer, Lapse, N, Log) ->
     Now = erlang:timestamp(), % PDU received.  PDU handling starts now!

--- a/src/smpp_session.erl
+++ b/src/smpp_session.erl
@@ -222,7 +222,7 @@ handle_accept(Pid, Sock, ProxyIpList) ->
     case inet:peername(Sock) of
         {ok, {Addr, _Port}} ->
             lager:debug("sync_send_event accept to pid:~p Addr:~p, proxy_ip_list: ~p", [Pid, Addr, ProxyIpList]),
-            case lists:meber(Addr, ProxyIpList) of
+            case lists:member(Addr, ProxyIpList) of
                 true -> case proxy_protocol:accept(Sock) of
                             {ok, {proxy_opts, _IpVersion, SourceAddress, DestAddress, SourcePort, DestPort, ConnectionInfo}} ->
                                 gen_fsm:sync_send_event(Pid,

--- a/src/time.erl
+++ b/src/time.erl
@@ -1,0 +1,11 @@
+-module(time).
+
+-export([timestamp/0]).
+
+timestamp() ->
+   OtpRelease = list_to_integer(erlang:system_info(otp_release)),
+   case OtpRelease of
+      17 -> erlang:now();
+      n when n >= 18 -> erlang:timestamp();
+      _ -> {error, "OTP verstion is not supported"}
+   end.

--- a/src/time.erl
+++ b/src/time.erl
@@ -6,6 +6,6 @@ timestamp() ->
    OtpRelease = list_to_integer(erlang:system_info(otp_release)),
    case OtpRelease of
       17 -> erlang:now();
-      n when n >= 18 -> erlang:timestamp();
+      N when N >= 18 -> erlang:timestamp();
       _ -> {error, "OTP verstion is not supported"}
    end.


### PR DESCRIPTION
Proxy protocol v2 implementation
Use `proxy_ip_list` option for `gen_mc:start_link` to declare list of IPv4 (4 digit touple) addresses
```
Example:
Opts = [{addr, Addr}, {port, Port}, {rps, false}, {proxy_ip_list, [{172,17,0,2}]}],
gen_mc:start_link({local, ServerName}, ?MODULE, [], Opts).
```
Then you need to implement `handle_accept(Pid, {Addr, ProxyOpts}, From, St)` function,
where ProxyOpts is a List of
```
[source_address :: inet:ip_address(),
dest_address :: inet:ip_address(),
source_port :: inet:port_number(),
dest_port :: inet:port_number(),
connection_info = []]
```