### PR TITLE
Add handle_error callback to gen_esme

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-OSERL 3.2.3 needs common_lib 3.3.0 or higher.
+OSERL 5.0.0 needs common_lib 3.3.0 or higher.
 
 Documentation available in man format:
 

--- a/doc/examples/esme_skel.erl
+++ b/doc/examples/esme_skel.erl
@@ -57,6 +57,7 @@
          handle_outbind/2,
          handle_req/4,
          handle_resp/3,
+         handle_error/3,
          handle_unbind/3]).
 
 %%% MACROS
@@ -136,6 +137,10 @@ handle_req(_Req, _Args, _Ref, St) ->
 
 
 handle_resp(_Resp, _Ref, St) ->
+    {noreply, St}.
+
+
+handle_error(_Resp, _Ref, St) ->
     {noreply, St}.
 
 

--- a/doc/examples/sample_esme.erl
+++ b/doc/examples/sample_esme.erl
@@ -63,6 +63,7 @@
          handle_outbind/2,
          handle_req/4,
          handle_resp/3,
+         handle_error/3,
          handle_unbind/3]).
 
 %%% CONNECT EXPORTS
@@ -270,7 +271,8 @@ handle_resp({error, Reason}, Ref, St) ->
     submit(Params, Args, ?LOW),
     {noreply, St#st{reqs = Reqs}}.
 
-
+handle_error({error, Reason} = Error, Ref, St) ->
+    handle_resp(Error, Ref, St).
 
 handle_unbind(_Pdu, _From, St) ->
     {reply, ok, St}.

--- a/doc/gen_esme.ndoc
+++ b/doc/gen_esme.ndoc
@@ -249,7 +249,8 @@ to the other peer.
 
 The callback ``handle_req/4`` is called to notify the reference of the request
 to the callback module.  This reference is later passed as the second argument
-to ``handle_resp/3`` when the response arrives.
+to ``handle_resp/3`` when the response arrives or to ``handle_error/3`` when
+not.
 
 
 ``Args`` is an arbitrary term that is passed as is to ``handle_req/4``.
@@ -304,7 +305,8 @@ request does not go through the ESME queue and is not controlled by the
 throttler.  Right after sending the request to the other peer, the callback
 ``handle_req/4`` is called to notify the reference of the request to the
 callback module.  This reference is later passed as the second argument to
-``handle_resp/3`` when the response arrives.
+``handle_resp/3`` when the response arrives or to ``handle_error/3`` when
+not.
 
 ``Args`` is an arbitrary term that is passed as is to ``handle_req/4``.  The
 default ``Timeout`` is 2 minutes (TCP SYN_SENT).
@@ -324,7 +326,8 @@ request is issued immediately.  The request does not go through the ESME queue
 and is not controlled by the throttler.  Right after sending the request to the
 other peer, the callback ``handle_req/4`` is called to notify the reference of
 the request to the callback module.  This reference is later passed as the
-second argument to ``handle_resp/3`` when the response arrives.
+second argument to ``handle_resp/3`` when the response arrives or to ``handle_error/3`` when
+not.
 
 ``Args`` is an arbitrary term that is passed as is to ``handle_req/4``.
 
@@ -382,7 +385,8 @@ The function returns ``ok`` and the SMPP request is inserted into the ESME
 queue.  Once the request is sent to the other peer, the callback
 ``handle_req/4`` is called to notify the reference of the request to the
 callback module.  This reference is later passed as the second argument to
-``handle_resp/3`` when the response arrives.
+``handle_resp/3`` when the response arrives or to ``handle_error/3`` when
+not.
 
 If unspecified ``Priority`` is ``10``.  ``0`` is the highest priority.  Requests
 with higher priority are processed first.
@@ -788,7 +792,7 @@ Forwards an outbind operation (from the peer MC) to the callback module.
 
 This callback is called when the request ``Req`` is submitted to the other
 peer.  ``Ref`` is the reference of the request that can be later used to
-match the response arriving in ``handle_resp/3``.
+match the response arriving in ``handle_resp/3`` or in ``handle_error/3``.
 
 
 == handle_resp(Resp, Ref, St) -> Result ==
@@ -807,6 +811,26 @@ match the response arriving in ``handle_resp/3``.
 
 
 This callback is called when the response ``Resp`` associated to the request
+with reference ``Ref`` arrives.  SMPP related errors are returned as tuples
+with the format ``{command_status, CmdStatus}``.  If an unexpected error ocurrs
+``Reason`` will be a term indicating the failure reason.
+
+== handle_error(Error, Ref, St) -> Result ==
+
+: Types
+ : Error = {error, Reason}
+ : PduResp = pdu()
+ : Reason = {command_status, CmdStatus} | term()
+ : CmdStatus = int()
+ : Ref = ref()
+ : St = term()
+ : Result = {noreply, NewSt} | {noreply, NewSt, Timeout} | {stop, Reason, NewSt}
+ : NewSt = term()
+ : Timeout = int()
+ : Reason = term()
+
+
+This callback is called when the error ``Error`` associated to the request
 with reference ``Ref`` arrives.  SMPP related errors are returned as tuples
 with the format ``{command_status, CmdStatus}``.  If an unexpected error ocurrs
 ``Reason`` will be a term indicating the failure reason.

--- a/doc/gen_esme_session.ndoc
+++ b/doc/gen_esme_session.ndoc
@@ -205,7 +205,8 @@ Issues a //broadcast_sm//, //cancel_broadcast_sm//, //cancel_sm//, //data_sm//,
 //submit_sm//, operation asynchronously.
 
 This function returns immediately the reference of the response.  The response
-will be received in the ``handle_resp/3`` callback.
+will be received in the ``handle_resp/3`` callback, or in ``handle_error/3`` when error
+occurred without response from MC (for example, timeout or no network connection)
 
 
 == unbind(SessionRef) -> Ref ==
@@ -337,6 +338,27 @@ Response is ignored by the session.
 Delivers a response to the callback module.  ``Ref`` is the reference as
 returned by the asynchronous requests and ``Resp`` is either ``{ok, PduResp}``
 or ``{error, Reason}``.  In SMPP errors ``Reason`` has the format
+``{command_status, CmdStatus}``.  In erlang related errors ``Reason`` will be
+the term as returned by the failing function.
+
+``Esme`` is the ESME's process id.
+
+
+== handle_error(Esme, Error, Ref) -> ok ==
+
+: Types
+ : Esme = pid()
+ : Addr = ip_address()
+ : Error = {error, Reason}
+ : Reason = {command_status, CmdStatus} | term()
+ : PduRsp = pdu()
+ : CmdStatus = int()
+ : Ref = ref()
+
+
+Delivers a error response to the callback module.  ``Ref`` is the reference as
+returned by the asynchronous requests and ``Error`` is ``{error, Reason}``.
+In SMPP errors ``Reason`` has the format
 ``{command_status, CmdStatus}``.  In erlang related errors ``Reason`` will be
 the term as returned by the failing function.
 

--- a/ebin/oserl.app
+++ b/ebin/oserl.app
@@ -1,6 +1,6 @@
 {application, oserl, [
     {description, "Open SMPP Erlang Library"},
-    {vsn, "3.2.4"},
+    {vsn, "5.0.0"}, % version 4 already used.
     {modules, [
         gen_esme_session,
         gen_esme,


### PR DESCRIPTION
In current state of the library we can't divide errors gotten from MC server from those which occurred locally, for example, when there is no network connection. In this PR i'm tried to solve that issue by providing additional calback `handle_error/3` inside `gen_esme` behavior.